### PR TITLE
Fix/tutorial issue

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -385,12 +385,10 @@ function handleCompletionPage(settings: AppSettings) {
     if (settings.isTutorialMode) {
         console.log('Tutorial Mode: OFF. Future runs will auto-close.');
         chrome.storage.local.set({ [STORAGE_KEYS.IS_TUTORIAL_MODE]: false });
-        // NOTE: In Tutorial Mode, we do NOT close the tab even on completion,
-        // so the user can clearly see "Run Completed" and check their browser settings if needed.
-        // OR should we close it? User requirement was "Don't close to allow popup permission".
-        // Once completed, popup permission IS granted (presumably).
-        // But for safety/feedback, let's keep it open this one time.
-    } else if (settings.closeTab) {
+        return;
+    }
+
+    if (settings.closeTab) {
         console.log('Closing Main Tab (as per settings)...');
         // Close the homepage
         chrome.runtime.sendMessage({ action: 'closeMainTab' });
@@ -480,12 +478,10 @@ function performLauncherPageLogic(settings: AppSettings) {
                     `No match found among buttons: ${buttonInfo}`
                 );
 
-                if (settings.closeTab) {
-                    console.log(
-                        '[performLauncherPageLogic] Mismatch detected. Triggering Smart Timeout (2s)...'
-                    );
-                    chrome.runtime.sendMessage({ action: 'notifyMismatchDetected' });
-                }
+                console.log(
+                    '[performLauncherPageLogic] Mismatch detected. Triggering Smart Timeout (2s)...'
+                );
+                chrome.runtime.sendMessage({ action: 'notifyMismatchDetected' });
             }
         }
         return false;


### PR DESCRIPTION
## 변경 사항 요약

2026-01-04 이후 변경된 POE2 카카오게임즈 게임 시작 후 팝업 순서로 인한 사이드 이팩트 조치

`자동 실행 후 탭 닫기`가 최초 게임 1회 실행 후 정상적으로 사용할 수 있어야 하지만 일부 환경에서 동작 하지 않고 있었음

해당 이슈는 마지막 팝업인 `LauncherCompletionHandler`에서 게임 시작을 확인하고 닫고 있지만,
지정 PC를 사용하지 않는 일부 환경에서는 `LauncherCheckHandler`에서 바로 게임이 시작되며 트리거가 활성화 되지 않고 있음을 확인함.

## 관련 이슈

- Fixes: #63

## 체크리스트

- [x] 코드 스타일 가이드를 준수했습니다.
- [ ] 모든 빌드 및 테스트가 정상적으로 통과되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

## 스크린샷 (선택사항)

<img width="940" height="1820" alt="image" src="https://github.com/user-attachments/assets/ff63272c-dd28-4c91-abf7-6b60c630a3bd" />


