### PR TITLE
카카오게임즈 홈페이지 변경 후 자동 실행 복구

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 CHANGELOG.md
+
+manifest.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,10 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": "explicit"
     },
+    "terminal.integrated.automationProfile.windows": {
+        "path": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+        "args": ["-NoProfile"]
+    },
     "sonarlint.connectedMode.project": {
         "connectionId": "nerdhead-lab",
         "projectKey": "NERDHEAD-lab_POE2-quick-launch-for-kakao"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,19 +2,30 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "npm: install",
-            "type": "npm",
-            "script": "setup",
+            "label": "npm: install(poe-poe2-quick-launch-for-kakao)",
+            "type": "shell",
+            "command": "pwsh.exe",
+            "args": [
+                "-NoProfile",
+                "-Command",
+                "Set-Location -LiteralPath 'D:\\project_poe2\\POE2-quick-launch-for-kakao'; npm run setup"
+            ],
+            "problemMatcher": [],
             "presentation": {
                 "reveal": "silent",
                 "panel": "shared"
             }
         },
         {
-            "label": "npm: dev",
-            "type": "npm",
-            "script": "dev",
-            "dependsOn": ["npm: install"],
+            "label": "npm: dev(poe-poe2-quick-launch-for-kakao)",
+            "type": "shell",
+            "command": "pwsh.exe",
+            "args": [
+                "-NoProfile",
+                "-Command",
+                "Set-Location -LiteralPath 'D:\\project_poe2\\POE2-quick-launch-for-kakao'; npm run dev"
+            ],
+            "dependsOn": ["npm: install(poe-poe2-quick-launch-for-kakao)"],
             "detail": "Start the development server",
             "problemMatcher": [],
             "presentation": {
@@ -25,6 +36,21 @@
             "runOptions": {
                 "runOn": "folderOpen"
             }
+        },
+        {
+            "label": "npm: build(poe-poe2-quick-launch-for-kakao)",
+            "type": "shell",
+            "command": "pwsh.exe",
+            "args": [
+                "-NoProfile",
+                "-Command",
+                "Set-Location -LiteralPath 'D:\\project_poe2\\POE2-quick-launch-for-kakao'; npm run build"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
             "matches": [
                 "*://*.game.daum.net/*",
                 "*://*.daum.net/*",
+                "*://*.kakaogames.com/*",
                 "*://*.kakao.com/*"
             ],
             "js": [
@@ -43,6 +44,7 @@
     "host_permissions": [
         "*://*.game.daum.net/*",
         "*://*.daum.net/*",
+        "*://*.kakaogames.com/*",
         "*://*.kakao.com/*",
         "*://nerdhead-lab.github.io/*",
         "http://127.0.0.1/*"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,16 +3,16 @@
  */
 export const EXT_URLS = {
     POE: {
-        HOMEPAGE: 'https://poe.game.daum.net/',
-        AUTO_START: 'https://poe.game.daum.net#autoStart',
+        HOMEPAGE: 'https://poe.kakaogames.com/',
+        AUTO_START: 'https://poe.kakaogames.com#autoStart',
         TRADE: 'https://poe.game.daum.net/trade',
-        PATCH_NOTES_FORUM: 'https://poe.game.daum.net/forum/view-forum/patch-notes'
+        PATCH_NOTES_FORUM: 'https://poe.kakaogames.com/forum/view-forum/patch-notes'
     },
     POE2: {
-        HOMEPAGE: 'https://pathofexile2.game.daum.net/main',
-        AUTO_START: 'https://pathofexile2.game.daum.net/main#autoStart',
+        HOMEPAGE: 'https://pathofexile2.kakaogames.com/main',
+        AUTO_START: 'https://pathofexile2.kakaogames.com/main#autoStart',
         TRADE: 'https://poe.game.daum.net/trade2',
-        PATCH_NOTES_FORUM: 'https://poe.game.daum.net/forum/view-forum/patch-notes2'
+        PATCH_NOTES_FORUM: 'https://poe.kakaogames.com/forum/view-forum/patch-notes2'
     },
     NOTICE_JSON: 'https://nerdhead-lab.github.io/POE2-quick-launch-for-kakao/notice.json'
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,13 +5,13 @@ export const EXT_URLS = {
     POE: {
         HOMEPAGE: 'https://poe.kakaogames.com/',
         AUTO_START: 'https://poe.kakaogames.com#autoStart',
-        TRADE: 'https://poe.game.daum.net/trade',
+        TRADE: 'https://poe.kakaogames.com/trade',
         PATCH_NOTES_FORUM: 'https://poe.kakaogames.com/forum/view-forum/patch-notes'
     },
     POE2: {
         HOMEPAGE: 'https://pathofexile2.kakaogames.com/main',
         AUTO_START: 'https://pathofexile2.kakaogames.com/main#autoStart',
-        TRADE: 'https://poe.game.daum.net/trade2',
+        TRADE: 'https://poe.kakaogames.com/trade2',
         PATCH_NOTES_FORUM: 'https://poe.kakaogames.com/forum/view-forum/patch-notes2'
     },
     NOTICE_JSON: 'https://nerdhead-lab.github.io/POE2-quick-launch-for-kakao/notice.json'

--- a/src/content.ts
+++ b/src/content.ts
@@ -2,6 +2,17 @@ import { BUTLER_PARAMS } from './constants';
 import { SELECTORS } from './domSelectors';
 import { loadSettings, AppSettings, STORAGE_KEYS } from './storage';
 import { LogData } from './types/message';
+import {
+    KAKAO_HOSTS,
+    isDaumLoginUrl,
+    isKakaoAuthUrl,
+    isKakaoGamesMemberLoginUrl,
+    isKnownKakaoReferrer,
+    isLauncherUrl,
+    isPoe2HomeUrl,
+    isPoeHomeUrl,
+    isSecurityCenterUrl
+} from './urlPolicy';
 import { startContextHeartbeat } from './utils/context';
 import { safeClick, observeAndInteract } from './utils/dom';
 
@@ -30,9 +41,31 @@ interface PageHandler {
     name: string;
     description: string;
     match: (url: URL) => boolean;
-    allowedReferrers?: string[];
+    allowedReferrers?: readonly string[];
     execute: (settings: AppSettings) => void;
 }
+
+const LAUNCHER_REFERRERS = [
+    ...KAKAO_HOSTS.poeHome,
+    ...KAKAO_HOSTS.poe2Home,
+    ...KAKAO_HOSTS.daumLogin,
+    ...KAKAO_HOSTS.member,
+    ...KAKAO_HOSTS.launcher
+];
+
+const LOGIN_REFERRERS = [...KAKAO_HOSTS.launcher];
+const KAKAO_AUTH_REFERRERS = [
+    ...KAKAO_HOSTS.daumLogin,
+    ...KAKAO_HOSTS.member,
+    ...KAKAO_HOSTS.kakaoAccount
+];
+const SECURITY_REFERRERS = [
+    ...KAKAO_HOSTS.launcher,
+    ...KAKAO_HOSTS.kakaoAccount,
+    ...KAKAO_HOSTS.kakaoAuth,
+    ...KAKAO_HOSTS.member
+];
+const COMPLETION_REFERRERS = [...KAKAO_HOSTS.securityCenter, ...KAKAO_HOSTS.launcher];
 
 // -----------------------------------------------------------------------------
 // Logging Helper
@@ -73,12 +106,12 @@ chrome.runtime.onMessage.addListener((message) => {
 const PoeMainHandler: PageHandler = {
     name: 'PoeMainHandler',
     description: 'POE1 Homepage - Auto Start',
-    match: (url) => url.hostname === 'poe.game.daum.net',
+    match: isPoeHomeUrl,
     execute: (settings) => {
         console.log(`[Handler Execute] ${PoeMainHandler.description}`);
         if (globalThis.location.hash.includes(BUTLER_PARAMS.HASH)) {
             console.log('Auto Start triggered on POE.');
-            startMainPagePolling(settings, SELECTORS.POE.BTN_GAME_START);
+            startMainPagePolling(settings, SELECTORS.POE.BTN_GAME_START, isPoeStartButton);
         }
     }
 };
@@ -86,7 +119,7 @@ const PoeMainHandler: PageHandler = {
 const Poe2MainHandler: PageHandler = {
     name: 'Poe2MainHandler',
     description: 'POE2 Homepage - Auto Start & Modal Handling',
-    match: (url) => url.hostname === 'pathofexile2.game.daum.net' && url.pathname.includes('/main'),
+    match: isPoe2HomeUrl,
     execute: (settings) => {
         console.log(`[Handler Execute] ${Poe2MainHandler.description}`);
         const shouldDismissToday = settings.closePopup;
@@ -129,7 +162,7 @@ const Poe2MainHandler: PageHandler = {
                 }
             }
 
-            startMainPagePolling(settings, SELECTORS.POE2.BTN_GAME_START);
+            startMainPagePolling(settings, SELECTORS.POE2.BTN_GAME_START, isPoe2StartButton);
         }
     }
 };
@@ -138,19 +171,14 @@ const LauncherCheckHandler: PageHandler = {
     name: 'LauncherCheckHandler',
     description: 'Launcher Game Start Check & Init Page (When Not Logged In)',
     match: (url) => {
-        if (url.hostname !== 'pubsvc.game.daum.net') return false;
+        if (!isLauncherUrl(url)) return false;
         // Check for specific game start pages (poe.html or poe2.html)
         return (
             url.pathname.includes('/gamestart/poe.html') ||
             url.pathname.includes('/gamestart/poe2.html')
         );
     },
-    allowedReferrers: [
-        'poe.game.daum.net',
-        'pathofexile2.game.daum.net',
-        'logins.daum.net',
-        'pubsvc.game.daum.net'
-    ],
+    allowedReferrers: LAUNCHER_REFERRERS,
     execute: (settings) => {
         const urlParams = new URLSearchParams(globalThis.location.search);
         const paramsObj: Record<string, string> = {};
@@ -170,7 +198,7 @@ const DaumLoginHandler: PageHandler = {
     name: 'DaumLoginHandler',
     description: 'Daum Login Check Page (When Not Logged In) - Auto Click Kakao Login',
     match: (url) => {
-        if (url.hostname !== 'logins.daum.net') return false;
+        if (!isDaumLoginUrl(url)) return false;
 
         // Verify 'url' parameter validates against LauncherCheckHandler logic (targets POE/POE2)
         const nextUrlParam = url.searchParams.get('url');
@@ -179,7 +207,7 @@ const DaumLoginHandler: PageHandler = {
         try {
             const nextUrl = new URL(decodeURIComponent(nextUrlParam)); // Decoded target URL
             return (
-                nextUrl.hostname === 'pubsvc.game.daum.net' &&
+                isLauncherUrl(nextUrl) &&
                 (nextUrl.pathname.includes('/gamestart/poe.html') ||
                     nextUrl.pathname.includes('/gamestart/poe2.html'))
             );
@@ -187,15 +215,46 @@ const DaumLoginHandler: PageHandler = {
             return false;
         }
     },
-    allowedReferrers: ['pubsvc.game.daum.net'],
+    allowedReferrers: LOGIN_REFERRERS,
     execute: (_settings) => {
         console.log(`[Handler Execute] ${DaumLoginHandler.description}`);
         chrome.runtime.sendMessage({ action: 'notifyHandlerTriggered' });
-        const kakaoLoginBtn = document.querySelector(SELECTORS.LOGIN_DAUM.BTN_KAKAO_LOGIN);
+        const kakaoLoginBtn =
+            document.querySelector(SELECTORS.LOGIN_DAUM.BTN_KAKAO_LOGIN) ||
+            document.querySelector(SELECTORS.LOGIN_DAUM.BTN_KAKAO_LEGACY);
         if (kakaoLoginBtn) {
             console.log('Found "Kakao Login" button. Clicking...');
             safeClick(kakaoLoginBtn as HTMLElement);
         }
+    }
+};
+
+const KakaoGamesMemberLoginHandler: PageHandler = {
+    name: 'KakaoGamesMemberLoginHandler',
+    description: 'Kakao Games Member Login - Auto Click Kakao Login',
+    match: isKakaoGamesMemberLoginUrl,
+    execute: (_settings) => {
+        console.log(`[Handler Execute] ${KakaoGamesMemberLoginHandler.description}`);
+        chrome.runtime.sendMessage({ action: 'notifyHandlerTriggered' });
+        observeAndInteract((obs) => {
+            const kakaoLoginBtn =
+                document.querySelector(SELECTORS.KAKAO_GAMES_MEMBER.BTN_KAKAO_LOGIN) ||
+                Array.from(document.querySelectorAll('button')).find((button) => {
+                    const text = button.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+                    return (
+                        text.includes('카카오 로그인') ||
+                        text.toLowerCase().includes('kakao login') ||
+                        Boolean(button.querySelector(SELECTORS.KAKAO_GAMES_MEMBER.BTN_KAKAO_ICON))
+                    );
+                });
+
+            if (!kakaoLoginBtn) return false;
+
+            console.log('Found "Kakao Login" button. Clicking...');
+            safeClick(kakaoLoginBtn as HTMLElement);
+            if (obs) obs.disconnect();
+            return true;
+        });
     }
 };
 
@@ -309,8 +368,8 @@ const KakaoSimpleLoginHandler: PageHandler = {
 const KakaoAuthHandler: PageHandler = {
     name: 'KakaoAuthHandler',
     description: 'Kakao Auth/Continue Page (When Not Logged In) - Auto Click Agree',
-    match: (url) => url.hostname === 'kauth.kakao.com' && url.pathname.includes('/oauth/authorize'),
-    allowedReferrers: ['logins.daum.net', 'accounts.kakao.com'],
+    match: (url) => isKakaoAuthUrl(url) && url.pathname.includes('/oauth/authorize'),
+    allowedReferrers: KAKAO_AUTH_REFERRERS,
     execute: (_settings) => {
         console.log(`[Handler Execute] ${KakaoAuthHandler.description}`);
         const agreeBtn = document.querySelector(SELECTORS.KAKAO_AUTH.BTN_AGREE) as HTMLElement;
@@ -324,8 +383,8 @@ const KakaoAuthHandler: PageHandler = {
 const SecurityCenterHandler: PageHandler = {
     name: 'SecurityCenterHandler',
     description: 'Designated PC / Security Page - Auto Click Confirm',
-    match: (url) => url.hostname === 'security-center.game.daum.net',
-    allowedReferrers: ['pubsvc.game.daum.net', 'accounts.kakao.com', 'kauth.kakao.com'],
+    match: isSecurityCenterUrl,
+    allowedReferrers: SECURITY_REFERRERS,
     execute: (_settings) => {
         console.log(`[Handler Execute] ${SecurityCenterHandler.description}`);
         chrome.runtime.sendMessage({ action: 'notifyHandlerTriggered' });
@@ -341,14 +400,14 @@ const LauncherCompletionHandler: PageHandler = {
     name: 'LauncherCompletionHandler',
     description: 'Launcher Execution Confirmation Page',
     match: (url) => {
-        if (url.hostname !== 'pubsvc.game.daum.net') return false;
+        if (!isLauncherUrl(url)) return false;
         if (!url.pathname.includes('/securitycenter') || !url.pathname.includes('/completed.html'))
             return false;
 
         const gameCode = url.searchParams.get('gameCode');
         return gameCode === 'poe' || gameCode === 'poe2';
     },
-    allowedReferrers: ['security-center.game.daum.net', 'pubsvc.game.daum.net'],
+    allowedReferrers: COMPLETION_REFERRERS,
     execute: (settings) => {
         console.log(`[Handler Execute] ${LauncherCompletionHandler.description}`);
         chrome.runtime.sendMessage({ action: 'notifyHandlerTriggered' });
@@ -369,6 +428,7 @@ const HANDLERS: PageHandler[] = [
     // 로그인 하지 않을 경우에만 동작하는 헨들러
     LauncherCheckHandler, //로그인 되었을 경우에는 팝업이 발생은 하지만 알아서 처리됨. 플러그인에서는 관여 X
     DaumLoginHandler,
+    KakaoGamesMemberLoginHandler,
     KakaoSimpleLoginHandler,
     KakaoAuthHandler,
     // 게임 시작에 관여하는 헨들러
@@ -399,7 +459,7 @@ function dispatchPageLogic(settings: AppSettings) {
         // Referrer Validation
         if (handler.allowedReferrers) {
             const currentReferrer = document.referrer;
-            const isValid = handler.allowedReferrers.some((ref) => currentReferrer.includes(ref));
+            const isValid = isKnownKakaoReferrer(currentReferrer, handler.allowedReferrers);
 
             if (!isValid) {
                 console.warn(
@@ -422,13 +482,17 @@ function dispatchPageLogic(settings: AppSettings) {
 // -----------------------------------------------------------------------------
 
 // Unified Main Page Polling Logic
-function startMainPagePolling(_settings: AppSettings, buttonSelector: string) {
+function startMainPagePolling(
+    _settings: AppSettings,
+    buttonSelector: string,
+    isFallbackMatch: (element: HTMLElement) => boolean
+) {
     let attempts = 0;
     const maxAttempts = 50; // 10 seconds (50 * 200ms)
 
     const interval = setInterval(() => {
         attempts++;
-        const startBtn = document.querySelector(buttonSelector) as HTMLElement;
+        const startBtn = findMainPageStartButton(buttonSelector, isFallbackMatch);
 
         if (startBtn) {
             // Refined Cleanup - Target only butler and #autoStart
@@ -471,9 +535,58 @@ function startMainPagePolling(_settings: AppSettings, buttonSelector: string) {
 
         if (attempts >= maxAttempts) {
             clearInterval(interval);
-            console.log(`Stopped polling for Start Button (${buttonSelector}). Not found.`);
+            console.log(
+                `Stopped polling for Start Button (${buttonSelector}). Not found. Candidates: ${describeClickableCandidates()}`
+            );
         }
     }, 200);
+}
+
+function findMainPageStartButton(
+    buttonSelector: string,
+    isFallbackMatch: (element: HTMLElement) => boolean
+): HTMLElement | null {
+    const selectorMatch = document.querySelector(buttonSelector);
+    if (selectorMatch) return selectorMatch as HTMLElement;
+
+    const fallbackMatch = Array.from(document.querySelectorAll<HTMLElement>('a, button')).find(
+        isFallbackMatch
+    );
+    return fallbackMatch ?? null;
+}
+
+function isPoeStartButton(element: HTMLElement): boolean {
+    if (element.id === 'signupButton') return true;
+    if ((element.getAttribute('onclick') ?? '').includes('kgPoe.launch')) return true;
+
+    return normalizeText(element).includes('지금 무료로 플레이하기');
+}
+
+function isPoe2StartButton(element: HTMLElement): boolean {
+    if (element.classList.contains('main-start__link')) return true;
+
+    const text = normalizeText(element);
+    return text === '게임 시작' || text === '게임시작';
+}
+
+function normalizeText(element: HTMLElement): string {
+    return (element.innerText || element.textContent || '').replace(/\s+/g, ' ').trim();
+}
+
+function describeClickableCandidates(): string {
+    return Array.from(document.querySelectorAll('a, button'))
+        .slice(0, 20)
+        .map((element) => {
+            const htmlElement = element as HTMLElement;
+            const text = normalizeText(htmlElement);
+            const id = htmlElement.id ? `#${htmlElement.id}` : '';
+            const className =
+                typeof htmlElement.className === 'string' && htmlElement.className
+                    ? `.${htmlElement.className.trim().replace(/\s+/g, '.')}`
+                    : '';
+            return `${htmlElement.tagName.toLowerCase()}${id}${className}[${text}]`;
+        })
+        .join(', ');
 }
 
 function handleCompletionPage(settings: AppSettings) {

--- a/src/domSelectors.ts
+++ b/src/domSelectors.ts
@@ -66,7 +66,16 @@ export const SELECTORS = {
     // -------------------------------------------------------------------------
     LOGIN_DAUM: {
         // "Kakao Login" button
-        BTN_KAKAO_LOGIN: '.login__container--btn-kakao'
+        BTN_KAKAO_LOGIN: '.login__container--btn-kakao',
+        BTN_KAKAO_LEGACY: '.link_kakao_login'
+    },
+
+    // -------------------------------------------------------------------------
+    // 4-1. Kakao Games Member Login Page (member.kakaogames.com)
+    // -------------------------------------------------------------------------
+    KAKAO_GAMES_MEMBER: {
+        BTN_KAKAO_LOGIN: 'button.btn-common.btn-type--icon.btn-type__emph3',
+        BTN_KAKAO_ICON: '.icon-kakaocapri'
     },
 
     // -------------------------------------------------------------------------

--- a/src/patch-notes.ts
+++ b/src/patch-notes.ts
@@ -50,7 +50,7 @@ export function parsePatchNotes(html: string, limit: number): PatchNote[] {
 
         if (titleEl && dateEl) {
             const title = titleEl.innerText.trim();
-            const link = `https://poe.game.daum.net${titleEl.getAttribute('href')}`;
+            const link = new URL(titleEl.getAttribute('href') ?? '', EXT_URLS.POE.HOMEPAGE).href;
             const dateStr = dateEl.innerText.replace(/^, /, '').trim();
 
             notes.push({

--- a/src/patch-notes.ts
+++ b/src/patch-notes.ts
@@ -49,9 +49,9 @@ export function parsePatchNotes(html: string, limit: number): PatchNote[] {
         const dateEl = row.querySelector('.postBy .post_date') as HTMLSpanElement;
 
         if (titleEl && dateEl) {
-            const title = titleEl.innerText.trim();
+            const title = getElementText(titleEl);
             const link = new URL(titleEl.getAttribute('href') ?? '', EXT_URLS.POE.HOMEPAGE).href;
-            const dateStr = dateEl.innerText.replace(/^, /, '').trim();
+            const dateStr = getElementText(dateEl).replace(/^, /, '');
 
             notes.push({
                 title,
@@ -63,6 +63,10 @@ export function parsePatchNotes(html: string, limit: number): PatchNote[] {
     }
 
     return notes;
+}
+
+function getElementText(element: Element): string {
+    return (element.textContent ?? '').trim();
 }
 
 export function getPatchNoteUrl(game: 'poe' | 'poe2'): string {

--- a/src/urlPolicy.ts
+++ b/src/urlPolicy.ts
@@ -1,0 +1,56 @@
+export const KAKAO_HOSTS = {
+    poeHome: ['poe.kakaogames.com', 'pathofexile.kakaogames.com', 'poe.game.daum.net'],
+    poe2Home: ['pathofexile2.kakaogames.com', 'pathofexile2.game.daum.net'],
+    launcher: ['pubsvc.kakaogames.com', 'pubsvc.game.daum.net'],
+    securityCenter: ['security-center.kakaogames.com', 'security-center.game.daum.net'],
+    member: ['member.kakaogames.com'],
+    daumLogin: ['logins.daum.net'],
+    kakaoAuth: ['kauth.kakao.com'],
+    kakaoAccount: ['accounts.kakao.com']
+} as const;
+
+export function isPoeHomeUrl(url: URL): boolean {
+    return includesHost(KAKAO_HOSTS.poeHome, url.hostname);
+}
+
+export function isPoe2HomeUrl(url: URL): boolean {
+    return includesHost(KAKAO_HOSTS.poe2Home, url.hostname);
+}
+
+export function isLauncherUrl(url: URL): boolean {
+    return includesHost(KAKAO_HOSTS.launcher, url.hostname);
+}
+
+export function isSecurityCenterUrl(url: URL): boolean {
+    return includesHost(KAKAO_HOSTS.securityCenter, url.hostname);
+}
+
+export function isDaumLoginUrl(url: URL): boolean {
+    return includesHost(KAKAO_HOSTS.daumLogin, url.hostname);
+}
+
+export function isKakaoGamesMemberLoginUrl(url: URL): boolean {
+    return (
+        includesHost(KAKAO_HOSTS.member, url.hostname) &&
+        url.pathname.replace(/\/+$/, '') === '/login' &&
+        !url.searchParams.has('code')
+    );
+}
+
+export function isKakaoAuthUrl(url: URL): boolean {
+    return includesHost(KAKAO_HOSTS.kakaoAuth, url.hostname);
+}
+
+export function isKnownKakaoReferrer(referrer: string, allowedHosts: readonly string[]): boolean {
+    if (!referrer) return false;
+
+    try {
+        return allowedHosts.includes(new URL(referrer).hostname);
+    } catch {
+        return allowedHosts.some((host) => referrer.includes(host));
+    }
+}
+
+function includesHost(hosts: readonly string[], hostname: string): boolean {
+    return hosts.includes(hostname);
+}

--- a/tests/url-policy.test.ts
+++ b/tests/url-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { EXT_URLS } from '../src/constants';
+import {
+    isKakaoGamesMemberLoginUrl,
+    isKnownKakaoReferrer,
+    isLauncherUrl,
+    isPoe2HomeUrl,
+    isPoeHomeUrl,
+    isSecurityCenterUrl,
+    KAKAO_HOSTS
+} from '../src/urlPolicy';
+
+describe('Kakao URL policy', () => {
+    it('uses current Kakao Games primary URLs', () => {
+        expect(EXT_URLS.POE.HOMEPAGE).toBe('https://poe.kakaogames.com/');
+        expect(EXT_URLS.POE2.HOMEPAGE).toBe('https://pathofexile2.kakaogames.com/main');
+    });
+
+    it('matches current and legacy homepage hosts', () => {
+        expect(isPoeHomeUrl(new URL('https://poe.kakaogames.com/'))).toBe(true);
+        expect(isPoeHomeUrl(new URL('https://pathofexile.kakaogames.com/'))).toBe(true);
+        expect(isPoeHomeUrl(new URL('https://poe.game.daum.net/'))).toBe(true);
+
+        expect(isPoe2HomeUrl(new URL('https://pathofexile2.kakaogames.com/'))).toBe(true);
+        expect(isPoe2HomeUrl(new URL('https://pathofexile2.kakaogames.com/main'))).toBe(true);
+        expect(isPoe2HomeUrl(new URL('https://pathofexile2.game.daum.net/main'))).toBe(true);
+    });
+
+    it('matches current launcher and security-center hosts', () => {
+        expect(isLauncherUrl(new URL('https://pubsvc.kakaogames.com/gamestart/poe2.html'))).toBe(
+            true
+        );
+        expect(isLauncherUrl(new URL('https://pubsvc.game.daum.net/gamestart/poe2.html'))).toBe(
+            true
+        );
+        expect(isSecurityCenterUrl(new URL('https://security-center.kakaogames.com/'))).toBe(true);
+        expect(isSecurityCenterUrl(new URL('https://security-center.game.daum.net/'))).toBe(true);
+    });
+
+    it('matches Kakao Games member login before OAuth code callback', () => {
+        expect(isKakaoGamesMemberLoginUrl(new URL('https://member.kakaogames.com/login'))).toBe(
+            true
+        );
+        expect(
+            isKakaoGamesMemberLoginUrl(new URL('https://member.kakaogames.com/login?code=done'))
+        ).toBe(false);
+    });
+
+    it('validates referrers by hostname', () => {
+        expect(
+            isKnownKakaoReferrer(
+                'https://pubsvc.kakaogames.com/gamestart/poe2.html',
+                KAKAO_HOSTS.launcher
+            )
+        ).toBe(true);
+        expect(isKnownKakaoReferrer('', KAKAO_HOSTS.launcher)).toBe(false);
+        expect(isKnownKakaoReferrer('https://example.com/', KAKAO_HOSTS.launcher)).toBe(false);
+    });
+});

--- a/tests/urls.test.ts
+++ b/tests/urls.test.ts
@@ -12,12 +12,13 @@ async function checkUrl(url: string, retries = 3): Promise<boolean> {
             // Some servers block HEAD, so GET is safer for "reachability" despite bandwidth
             const res = await fetch(url, {
                 method: 'GET',
+                redirect: 'manual',
                 signal: controller.signal,
                 headers: { 'User-Agent': 'Mozilla/5.0 (Testbot)' }
             });
             clearTimeout(timeoutId);
 
-            if (res.ok) return true;
+            if (res.ok || (res.status >= 300 && res.status < 400)) return true;
             console.warn(`[Attempt ${i + 1}] Failed: ${url} (Status: ${res.status})`);
         } catch (e) {
             console.warn(`[Attempt ${i + 1}] Error: ${url}`, e);


### PR DESCRIPTION
## Summary

- 카카오게임즈 서비스 전환 후 변경된 홈페이지, 런처, 로그인, 보안센터 호스트를 인식하도록 URL 정책을 추가했습니다.
- `member.kakaogames.com/login` 팝업에서 Kakao Login 버튼을 비공식 런처와 같은 observer 방식으로 자동 클릭하도록 처리했습니다.
- VS Code task가 WSL npm으로 실행되지 않도록 task 실행 경로를 Windows PowerShell로 고정했습니다.
- Windows PowerShell 기준으로 lint, build, URL/DOM 관련 테스트를 확인했습니다.

## Motivation

카카오게임즈 홈페이지 도메인 변경 이후 quick-launch 확장이 기존 `game.daum.net` 중심의 URL 및 referrer 조건에 묶여 자동 진행을 놓쳤습니다. 특히 신규 회원 로그인 팝업은 런타임 렌더링 후 버튼이 생기는 구조라 즉시 조회만으로는 클릭하지 못할 수 있어, 비공식 런처의 처리 방식에 맞춰 DOM observer 기반으로 보강했습니다.
